### PR TITLE
chore: use module-builder stub mode for more accurate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepack": "pnpm build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "release": "bumpp && npm publish && git push --follow-tags",
     "test:e2e": "vitest run test/e2e"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
We added a `prepare` command for nuxt-module-build which allows creating type stubs directly from the module without needing to apply to the playground as well. (https://github.com/nuxt/module-builder/pull/124)

It's the default for new modules (https://github.com/nuxt/starter/pull/392).

This should allow us to match types more appropriately for module authors (for example, disallowing auto-imports) in future.