### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -10,8 +10,8 @@ export default defineNuxtPlugin(nuxtApp => {
     createVuePlugin({
       plugins: [
         ...harlemPlugins.map(p => p()),
-        process.client && createClientSSRPlugin(),
-        process.server && createServerSSRPlugin(),
+        import.meta.client && createClientSSRPlugin(),
+        import.meta.server && createServerSSRPlugin(),
       ].filter(Boolean),
     })
   )


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).