### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,5 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
with v4 of the codecov action, we need to supply a codecov token (pointed out by @ricardogobbosouza). I've added the token in GH variables...